### PR TITLE
Minor fixes

### DIFF
--- a/chat_with_nerf/chat/grounder.py
+++ b/chat_with_nerf/chat/grounder.py
@@ -296,7 +296,7 @@ def ground_with_gpt(
         },
     }
     if len(landmark_location_list) > 0:
-        evaluation["Targe Candidate Distance to Landmark (meter)"] = {
+        evaluation["Target Candidate Distance to Landmark (meter)"] = {
             str(i): round(
                 math.sqrt(
                     (bbox["centroid"][0] - landmark_location_centroid[0]) ** 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 include-package-data = false
 
 [tool.setuptools.packages.find]
-include = ["chat_with_nerf"]
+include = ["chat_with_nerf*"]
 
 [project]
 name = "chat_with_nerf"


### PR DESCRIPTION
Just two typos, the one in `pyproject.toml` prevented installation of subfolders `visual_grounder`, `model` and `chat` when e.g. installing the repo as a python package in a package manager like pdm:

`pdm add git+https://github.com/sled-group/chat-with-nerf.git@main`